### PR TITLE
Fix spec on windows

### DIFF
--- a/spec/pycall/pytypeobject_wrapper_spec.rb
+++ b/spec/pycall/pytypeobject_wrapper_spec.rb
@@ -14,7 +14,12 @@ module PyCall
       specify do
         expect(PyCall.builtins.tuple === PyCall.tuple()).to eq(true)
         np = PyCall.import_module('numpy')
-        expect(np.int64 === np.asarray([1])[0]).to eq(true)
+        case RUBY_PLATFORM
+        when /mingw32/
+          expect(np.int32 === np.asarray([1])[0]).to eq(true)
+        else
+          expect(np.int64 === np.asarray([1])[0]).to eq(true)
+        end
         expect(np.integer === np.asarray([1])[0]).to eq(true)
       end
     end


### PR DESCRIPTION
Fix the following failure tha is occurred on Appvayor.

```
  1) PyCall::PyTypeObjectWrapper#=== should eq true
     Failure/Error: expect(np.int64 === np.asarray([1])[0]).to eq(true)
       expected: true
            got: false
       (compared using ==)
     # ./spec/pycall/pytypeobject_wrapper_spec.rb:17:in `block (3 levels) in <module:PyCall>'
```

Full log is available here: https://ci.appveyor.com/project/mrkn/pycall/build/job/xh5ga2l7mjy8ut5a