### PR TITLE
Alias to_ary for multiple assignment

### DIFF
--- a/ext/pycall/pycall.c
+++ b/ext/pycall/pycall.c
@@ -2078,6 +2078,7 @@ init_tuple(void)
   rb_define_singleton_method(cTuple, "new", pycall_tuple_s_new, -1);
   rb_define_method(cTuple, "length", pycall_tuple_length, 0);
   rb_define_method(cTuple, "to_a", pycall_tuple_to_a, 0);
+  rb_define_alias(cTuple, "to_ary", "to_a");
 }
 
 void

--- a/spec/pycall/tuple_spec.rb
+++ b/spec/pycall/tuple_spec.rb
@@ -22,6 +22,14 @@ module PyCall
       end
     end
 
+    describe '#to_ary' do
+      it 'is used for multiple assignment' do
+        (a1, a2, a3), (b1, b2, b3) = Tuple.new(subject, subject)
+        expect([a1, a2, a3]).to eq([1, 2, 3])
+        expect([b1, b2, b3]).to eq([1, 2, 3])
+      end
+    end
+
     describe '#inspect' do
       pending
     end


### PR DESCRIPTION
The following code does not work:

```
require 'pycall'

datasets   = PyCall.import_module('keras.datasets')
(x_train, y_train), (x_test, y_test) = datasets.mnist.load_data()
# => tuple, nil, nil, nil
```

This is because ruby does not use `to_a` for implicit conversion.
(see https://bugs.ruby-lang.org/issues/1393)

In order to solve this we should make an alias for `to_ary`.

