### PR TITLE
Introduce public C APIs

### DIFF
--- a/ext/pycall/pycall.c
+++ b/ext/pycall/pycall.c
@@ -1,4 +1,5 @@
 #include "pycall_internal.h"
+#include "pycall.h"
 #include <ruby/encoding.h>
 
 #include <stdarg.h>

--- a/ext/pycall/pycall.c
+++ b/ext/pycall/pycall.c
@@ -143,6 +143,12 @@ get_pyobj_ptr(VALUE obj)
   return pyobj;
 }
 
+PyObject *
+pycall_pyptr_get_pyobj_ptr(VALUE pyptr)
+{
+  return get_pyobj_ptr(pyptr);
+}
+
 static inline PyObject*
 try_get_pyobj_ptr(VALUE obj)
 {

--- a/ext/pycall/pycall.h
+++ b/ext/pycall/pycall.h
@@ -1,0 +1,21 @@
+#ifndef PYCALL_H
+#define PYCALL_H 1
+
+#if defined(__cplusplus)
+extern "C" {
+#if 0
+} /* satisfy cc-mode */
+#endif
+#endif
+
+VALUE pycall_pyptr_new(PyObject *pyobj);
+PyObject *pycall_pyptr_get_pyobj_ptr(VALUE pyptr);
+
+#if defined(__cplusplus)
+#if 0
+{ /* satisfy cc-mode */
+#endif
+} /* extern "C" { */
+#endif
+
+#endif /* PYCALL_H */


### PR DESCRIPTION
The following two functions will be public APIs:

```c
VALUE pycall_pyptr_new(PyObject *pyobj);
PyObject *pycall_pyptr_get_pyobj_ptr(VALUE pyptr);
```

@kou how about this?