### PR TITLE
add a syntax sugar (SomeClass(*args) for calling SomeClass.(*args)).

### DIFF
--- a/lib/pycall/import.rb
+++ b/lib/pycall/import.rb
@@ -86,10 +86,25 @@ module PyCall
           context = self
           context = (self == PyCall::Import.main_object) ? Object : self
           context.module_eval { const_set(name, pyobj) }
+          class_new_sugar(name, context)
         else
           define_singleton_method(name) { pyobj }
         end
       end
+    end
+
+    # define `SomeClassName(*args)` (singleton method; NO dot(.) between class name
+    # and open-parenthesis) in the specified context.
+    # this is a syntax sugar for `SomeClassName.(*args)`.
+    #
+    # ==== Args
+    # clsnm :: name of a class in the context.
+    # ctx :: context.
+    def class_new_sugar( clsnm, ctx )
+      clsobj = ctx.module_eval(clsnm.to_s)
+      define_singleton_method(clsnm) {|*args|
+             clsobj.(*args)
+      } if clsobj.class == Class
     end
 
     def constant_name?(name)

--- a/spec/pycall/import_spec.rb
+++ b/spec/pycall/import_spec.rb
@@ -73,6 +73,13 @@ module PyCall
           mod.pyfrom 'pycall.import_test', import: 'TestClass'
           expect(mod::TestClass).to be_kind_of(PyObjectWrapper)
         end
+        it 'defines a class and its initializer (singleton method) with the given name via hiearachical signature of modules' do
+          expect(mod).not_to be_respond_to(:TestClass)
+          mod.pyfrom 'pycall.import_test.TestClass', import: 'TestClass'
+          expect(mod::TestClass.class).to eq(Class)
+          expect(mod.TestClass(42).class).to eq(Object)
+          expect(mod.TestClass(42).test()).to eq('42')
+        end
       end
 
       context 'there is not the module with the given name' do


### PR DESCRIPTION
This patch makes us possible to write as follows:

```
require 'pycall/import'
include PyCall::Import

pyfrom 'keras.models', import: 'Sequential'
pyfrom 'keras.layers', import: ['Dense', 'Dropout']

# Sequential.(), Dense.(), Dropout.() WITHOUT dot(.)
model = Sequential() 
model.add(Dense(512, activation: 'relu', input_shape: [784,]))
model.add(Dropout(0.2))
```