### PR TITLE
Export PyObject convert functions

### DIFF
--- a/ext/pycall/pycall.c
+++ b/ext/pycall/pycall.c
@@ -734,7 +734,6 @@ pycall_libpython_helpers_m_compare(VALUE mod, VALUE op, VALUE pyptr_a, VALUE pyp
 }
 
 static int is_pyobject_wrapper(VALUE obj);
-static PyObject * pycall_pyobject_wrapper_get_pyobj_ptr(VALUE obj);
 
 VALUE
 pycall_getattr_default(VALUE obj, char const *name, VALUE default_value)
@@ -1256,7 +1255,7 @@ pycall_pyobject_wrapper_get_pyptr(VALUE obj)
   return rb_funcall(obj, rb_intern("__pyptr__"), 0);
 }
 
-static PyObject *
+PyObject *
 pycall_pyobject_wrapper_get_pyobj_ptr(VALUE obj)
 {
   VALUE pyptr = pycall_pyobject_wrapper_get_pyptr(obj);

--- a/ext/pycall/pycall.h
+++ b/ext/pycall/pycall.h
@@ -10,6 +10,8 @@ extern "C" {
 
 VALUE pycall_pyptr_new(PyObject *pyobj);
 PyObject *pycall_pyptr_get_pyobj_ptr(VALUE pyptr);
+VALUE pycall_pyobject_to_ruby(PyObject *pyobj);
+PyObject *pycall_pyobject_wrapper_get_pyobj_ptr(VALUE obj);
 
 #if defined(__cplusplus)
 #if 0

--- a/ext/pycall/pycall_internal.h
+++ b/ext/pycall/pycall_internal.h
@@ -645,7 +645,6 @@ VALUE pycall_import_module_level(char const *name, VALUE globals, VALUE locals, 
 VALUE pycall_getattr_default(VALUE pyobj, char const *name, VALUE default_value);
 VALUE pycall_getattr(VALUE pyobj, char const *name);
 
-VALUE pycall_pyobject_to_ruby(PyObject *);
 VALUE pycall_pytype_to_ruby(PyObject *);
 VALUE pycall_pymodule_to_ruby(PyObject *);
 VALUE pycall_pybool_to_ruby(PyObject *);


### PR DESCRIPTION
They are needed by Red Arrow PyCall.