### PR TITLE
Checking all pythons in DEFAULT_PYTHON.

### DIFF
--- a/lib/pycall/libpython/finder.rb
+++ b/lib/pycall/libpython/finder.rb
@@ -27,12 +27,12 @@ module PyCall
         def find_python_config(python = nil)
           python ||= DEFAULT_PYTHON
           Array(python).each do |python_cmd|
-            python_config = investigate_python_config(python_cmd)
-            return [python_cmd, python_config] unless python_config.empty?
+            begin
+              python_config = investigate_python_config(python_cmd)
+              return [python_cmd, python_config] unless python_config.empty?
+            rescue
+            end
           end
-        rescue
-          raise ::PyCall::PythonNotFound
-        else
           raise ::PyCall::PythonNotFound
         end
 


### PR DESCRIPTION
DEFAULT_PYTHON@lib/pycall/libpython/finder.rb is 'python3' and 'python' and find_python_config() tries all python configurations in DEFAULT_PYTHON.
But when 'python3' is not found, investigate_python_config() throws exception and returns from find_python_config() without checking 'python'.
This fix checks all pythons in DEFAULT_PYTHON.