### PR TITLE
update example

### DIFF
--- a/examples/classifier_comparison.rb
+++ b/examples/classifier_comparison.rb
@@ -2,7 +2,7 @@ require 'pycall/import'
 include PyCall::Import
 
 pyimport 'numpy', as: :np
-pyfrom 'sklearn.cross_validation', import: :train_test_split
+pyfrom 'sklearn.model_selection', import: :train_test_split
 pyfrom 'sklearn.preprocessing', import: :StandardScaler
 pyfrom 'sklearn.datasets', import: %i(make_moons make_circles make_classification)
 pyfrom 'sklearn.neighbors', import: :KNeighborsClassifier

--- a/examples/notebooks/classifier_comparison.ipynb
+++ b/examples/notebooks/classifier_comparison.ipynb
@@ -38,7 +38,7 @@
     "include PyCall::Import\n",
     "\n",
     "pyimport 'numpy', as: :np\n",
-    "pyfrom 'sklearn.cross_validation', import: :train_test_split\n",
+    "pyfrom 'sklearn.model_selection', import: :train_test_split\n",
     "pyfrom 'sklearn.preprocessing', import: :StandardScaler\n",
     "pyfrom 'sklearn.datasets', import: %i(make_moons make_circles make_classification)\n",
     "pyfrom 'sklearn.neighbors', import: :KNeighborsClassifier\n",


### PR DESCRIPTION
```
PyCall::PyError: <class 'ModuleNotFoundError'>: No module named 'sklearn.cross_validation'
```

use model_selection instead of cross_validation in examples.