### PR TITLE
Use density instead of normed

### DIFF
--- a/examples/hist.rb
+++ b/examples/hist.rb
@@ -20,7 +20,7 @@ num_bins = 50
 
 fig, ax = *plt.subplots
 
-n, bins, patches = *ax.hist(x, num_bins, normed: 1)
+n, bins, patches = *ax.hist(x, num_bins, density: 1)
 
 y = mlab.normpdf(bins, mu, sigma)
 ax.plot(bins, y, '--')


### PR DESCRIPTION
Fix warning
```
The 'normed' kwarg was deprecated in Matplotlib 2.1 and will be removed in 3.1. Use 'density' instead.
  alternative="'density'", removal="3.1")
```