### PR TITLE
Add PyCall.without_gvl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # The change history of PyCall
 
+## master
+
+* Add `PyCall.without_gvl` for explicitly releasing the RubyVM GVL
+
 ## 1.2.1
 
 * Prevent circular require in pycall/iruby.rb

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ the `Math.sin` in Ruby:
 Type conversions from Ruby to Python are automatically performed for numeric,
 boolean, string, arrays, and hashes.
 
+### Releasing the RubyVM GVL during Python function calls
+
+You may want to release the RubyVM GVL when you call a Python function that takes very long runtime.
+PyCall provides `PyCall.without_gvl` method for such purpose.  When PyCall performs python function call,
+PyCall checks the current context, and then it releases the RubyVM GVL when the current context is in a `PyCall.without_gvl`'s block.
+
+```ruby
+PyCall.without_gvl do
+  # In this block, all Python function calls are performed without
+  # the GVL acquisition.
+  pyobj.long_running_function()
+end
+
+# Outside of PyCall.without_gvl block,
+# all Python function calls are performed with the GVL acquisition.
+pyobj.long_running_function()
+```
+
 ### Debugging python finder
 
 When you encounter `PyCall::PythonNotFound` error, you can investigate PyCall's python finder by setting `PYCALL_DEBUG_FIND_LIBPYTHON` environment variable to `1`.  You can see the log like below:

--- a/ext/pycall/thread.c
+++ b/ext/pycall/thread.c
@@ -14,7 +14,7 @@ void *pycall_tls_get(pycall_tls_key tls_key)
 
 int pycall_tls_set(pycall_tls_key tls_key, void *ptr)
 {
-  return TlsSetValue(tls_key, th) == 0;
+  return 0 == TlsSetValue(tls_key, ptr);
 }
 #endif
 

--- a/ext/pycall/thread.c
+++ b/ext/pycall/thread.c
@@ -1,0 +1,36 @@
+#include "pycall_internal.h"
+
+#if defined(PYCALL_THREAD_WIN32)
+int pycall_tls_create(pycall_tls_key *tls_key)
+{
+  *tls_key = TlsAlloc();
+  return *tls_key == TLS_OUT_OF_INDEXES;
+}
+
+void *pycall_tls_get(pycall_tls_key tls_key)
+{
+  return TlsGetValue(tls_key);
+}
+
+int pycall_tls_set(pycall_tls_key tls_key, void *ptr)
+{
+  return TlsSetValue(tls_key, th) == 0;
+}
+#endif
+
+#if defined(PYCALL_THREAD_PTHREAD)
+int pycall_tls_create(pycall_tls_key *tls_key)
+{
+  return pthread_key_create(tls_key, NULL);
+}
+
+void *pycall_tls_get(pycall_tls_key tls_key)
+{
+  return pthread_getspecific(tls_key);
+}
+
+int pycall_tls_set(pycall_tls_key tls_key, void *ptr)
+{
+  return pthread_setspecific(tls_key, ptr);
+}
+#endif

--- a/spec/pycall/gvl_spec.rb
+++ b/spec/pycall/gvl_spec.rb
@@ -1,36 +1,71 @@
 require 'spec_helper'
 
-::RSpec.describe PyCall do
-  it 'releases GVL during Python C API invocation' do
-    py_time = PyCall.import_module('time')
+RSpec.describe PyCall do
+  context 'outside of PyCall.without_gvl' do
+    specify 'PyCall does not releases GVL during Python C API invocation' do
+      py_time = PyCall.import_module('time')
 
-    mutex = Mutex.new
-    cv = ConditionVariable.new
-    cancel = false
-    counter = Thread.start do
-      count = 0
-      mutex.synchronize do
-        until cancel
-          count += 1
-          cv.wait(mutex, 0.1)
+      mutex = Mutex.new
+      cv = ConditionVariable.new
+      cancel = false
+      counter = Thread.start do
+        count = 0
+        mutex.synchronize do
+          until cancel
+            count += 1
+            cv.wait(mutex, 0.1)
+          end
         end
+        count
       end
-      count
+
+      py_time.sleep(1)
+
+      mutex.synchronize do
+        cancel = true
+        cv.signal
+      end
+
+      expect(counter.value).to be < 5
     end
-
-    py_time.sleep(1)
-
-    mutex.synchronize do
-      cancel = true
-      cv.signal
-    end
-
-    expect(counter.value).to be >= 5
   end
 
-  it 'acquires GVL during calling Ruby from Python' do
-    gvl_checker = PyCall::GvlChecker.allocate
-    ruby_object_test = PyCall.import_module('pycall.ruby_object_test')
-    expect(ruby_object_test.call_callable(gvl_checker)).to eq(true)
+  context 'inside of .without_gvl' do
+    specify 'PyCall releases GVL during Python C API invocation' do
+      py_time = PyCall.import_module('time')
+
+      mutex = Mutex.new
+      cv = ConditionVariable.new
+      cancel = false
+      counter = Thread.start do
+        count = 0
+        mutex.synchronize do
+          until cancel
+            count += 1
+            cv.wait(mutex, 0.1)
+          end
+        end
+        count
+      end
+
+      PyCall.without_gvl do
+        py_time.sleep(1)
+      end
+
+      mutex.synchronize do
+        cancel = true
+        cv.signal
+      end
+
+      expect(counter.value).to be >= 5
+    end
+
+    specify 'PyCall acquires GVL during calling Ruby from Python' do
+      gvl_checker = PyCall::GvlChecker.allocate
+      ruby_object_test = PyCall.import_module('pycall.ruby_object_test')
+      PyCall.without_gvl do
+        expect(ruby_object_test.call_callable(gvl_checker)).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
PyCall currently release the RubyVM GVL implicitly when calling Python functions.
I want to stop this implicit GVL releasing.
Instead, I'd like to introduce `PyCall.without_gvl` method to control GVL acquisition for Python calls.

By this new method, we can explicitly specify the range of GVL releasing for Python calls like below:

```ruby
PyCall.without_gvl do
  # In this block, all Python function calls are performed without
  # the GVL acquisition.
  pyobj.long_running_function()
end

# Outside of PyCall.without_gvl block,
# all Python function calls are performed with the GVL acquisition.
pyobj.long_running_function()
```

#85 will resolve after merging this pull request.