### PR TITLE
[Proposal] Callable without args is regarded as a simple object (not called)

### DIFF
--- a/ext/pycall/pycall.c
+++ b/ext/pycall/pycall.c
@@ -1068,7 +1068,7 @@ pycall_pyobject_wrapper_wrapper_method(int argc, VALUE *argv, VALUE wrapper)
   if (!Py_API(PyCallable_Check)(attr))
     return pycall_pyobject_to_ruby(attr);
 
-  if (PyType_Check(attr) || PyClass_Check(attr) || argc == 0)
+  if (argc == 0)
     return pycall_pyobject_to_ruby(attr);
 
   return pycall_call_python_callable(attr, argc, argv);

--- a/ext/pycall/pycall.c
+++ b/ext/pycall/pycall.c
@@ -1068,7 +1068,7 @@ pycall_pyobject_wrapper_wrapper_method(int argc, VALUE *argv, VALUE wrapper)
   if (!Py_API(PyCallable_Check)(attr))
     return pycall_pyobject_to_ruby(attr);
 
-  if (PyType_Check(attr) || PyClass_Check(attr))
+  if (PyType_Check(attr) || PyClass_Check(attr) || argc == 0)
     return pycall_pyobject_to_ruby(attr);
 
   return pycall_call_python_callable(attr, argc, argv);

--- a/lib/pycall/import.rb
+++ b/lib/pycall/import.rb
@@ -77,18 +77,22 @@ module PyCall
     private
 
     def define_name(name, pyobj)
-      if callable?(pyobj) && !type_object?(pyobj)
-        define_singleton_method(name) do |*args|
-          LibPython::Helpers.call_object(pyobj.__pyptr__, *args)
-        end
+      if ! callable?(pyobj)
+        define_singleton_method(name){ pyobj }
       else
-        if constant_name?(name)
-          context = self
-          context = (self == PyCall::Import.main_object) ? Object : self
-          context.module_eval { const_set(name, pyobj) }
-        else
-          define_singleton_method(name) { pyobj }
+        define_singleton_method(name) do |*args|
+          if args.size > 0
+            LibPython::Helpers.call_object(pyobj.__pyptr__, *args)
+          else
+            pyobj
+          end
         end
+      end
+        
+      if constant_name?(name)
+        context = self
+        context = (self == PyCall::Import.main_object) ? Object : self
+        context.module_eval { const_set(name, pyobj) }
       end
     end
 


### PR DESCRIPTION
As issue #123 pointed out, np.add.at does not work with pycall.
In Python, np.add is callable, e.g. we can call np.add(a, b).
However, in Python, np.add itself is an object and it is different from np.add().

On the other side, in Ruby, np.add has the same meaning as np.add().
So np.add.at equal to np.add().at, which causes this error.

My proposal is as follows:
if a callable object appear without args, it is treated as a simple object in pycall.

A bad side effect of this patch is that when we call a callable object without any args,
we cannot write lke 'foo' or 'foo()' but we must write like 'foo.()'.

Another side effect is that when we call a callable object with some args,
we can write not only 'foo(x)' but also 'foo.(x)'.

