### PR TITLE
#121 - Revert "Remove conda checking"

### DIFF
--- a/lib/pycall/libpython/finder.rb
+++ b/lib/pycall/libpython/finder.rb
@@ -120,7 +120,7 @@ module PyCall
         end
 
         def set_PYTHONHOME(python_config)
-          if !ENV.has_key?('PYTHONHOME')
+          if !ENV.has_key?('PYTHONHOME') && python_config[:conda]
             case RUBY_PLATFORM
             when /mingw32/, /cygwin/, /mswin/
               ENV['PYTHONHOME'] = python_config[:exec_prefix]

--- a/lib/pycall/python/investigator.py
+++ b/lib/pycall/python/investigator.py
@@ -1,8 +1,12 @@
 from distutils.sysconfig import get_config_var
 import sys
 
+def conda():
+    return 'conda' in sys.version or 'Continuum' in sys.version
+
 for var in ('executable', 'exec_prefix', 'prefix'):
   print(var + ': ' + str(getattr(sys, var)))
+print('conda: ' + ('true' if conda() else 'false'))
 print('multiarch: ' + str(getattr(getattr(sys, 'implementation', sys), '_multiarch', None)))
 for var in ('VERSION', 'INSTSONAME', 'LIBRARY', 'LDLIBRARY', 'LIBDIR', 'PYTHONFRAMEWORKPREFIX', 'MULTIARCH'):
   print(var + ': ' + str(get_config_var(var)))


### PR DESCRIPTION
This reverts commit 2752e2e85a328bdbf251e859b902deaac4b2c182 and will, once again, not try to set the PYTHONHOME on my system.

Setting the `PYTHONHOME` is usually not a good idea, there are very very few cases where it makes sense. And it seems that in this specific case, trying to do it (`PYTHONHOME` is not defined in my environment) was breaking the work of python's `Lib/site.py`, which does that in a much saner way to begin with

With it, I no longer get problems as described in issue #121