### PR TITLE
Use st_table insterad of a Hash for GC guard table

### DIFF
--- a/ext/pycall/gc.c
+++ b/ext/pycall/gc.c
@@ -57,13 +57,16 @@ gcguard_aset(VALUE gcguard, PyObject *pyptr, VALUE rbobj)
 static void
 gcguard_delete(VALUE gcguard, PyObject *pyptr)
 {
-  struct gcguard *gg;
-  st_data_t key, val;
+  if (rb_typeddata_is_kind_of(gcguard, &gcguard_data_type)) {
+    /* This check is necessary to avoid error on the process finalization phase */
+    struct gcguard *gg;
+    st_data_t key, val;
 
-  TypedData_Get_Struct(gcguard, struct gcguard, &gcguard_data_type, gg);
+    TypedData_Get_Struct(gcguard, struct gcguard, &gcguard_data_type, gg);
 
-  key = (st_data_t)pyptr;
-  st_delete(gg->guarded_objects, &key, &val);
+    key = (st_data_t)pyptr;
+    st_delete(gg->guarded_objects, &key, &val);
+  }
 }
 
 static ID id_gcguard_table;

--- a/ext/pycall/gc.c
+++ b/ext/pycall/gc.c
@@ -1,5 +1,71 @@
 #include "pycall_internal.h"
 
+struct gcguard {
+  st_table *guarded_objects;
+};
+
+static int
+gcguard_mark_i(st_data_t key, st_data_t val, st_data_t arg)
+{
+  VALUE obj = (VALUE)val;
+  rb_gc_mark(obj);
+  return ST_CONTINUE;
+}
+
+static void
+gcguard_mark(void* ptr)
+{
+  struct gcguard *gg = (struct gcguard *)ptr;
+  st_foreach(gg->guarded_objects, gcguard_mark_i, 0);
+}
+
+static void
+gcguard_free(void* ptr)
+{
+  struct gcguard *gg = (struct gcguard *)ptr;
+  st_free_table(gg->guarded_objects);
+}
+
+static size_t
+gcguard_memsize(const void* ptr)
+{
+  const struct gcguard *gg = (const struct gcguard *)ptr;
+  return st_memsize(gg->guarded_objects);
+}
+
+static rb_data_type_t gcguard_data_type = {
+  "PyCall::gcguard",
+  {
+    gcguard_mark,
+    gcguard_free,
+    gcguard_memsize,
+  },
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
+  0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+#endif
+};
+
+static void
+gcguard_aset(VALUE gcguard, PyObject *pyptr, VALUE rbobj)
+{
+  struct gcguard *gg;
+  TypedData_Get_Struct(gcguard, struct gcguard, &gcguard_data_type, gg);
+
+  st_insert(gg->guarded_objects, (st_data_t)pyptr, (st_data_t)rbobj);
+}
+
+static void
+gcguard_delete(VALUE gcguard, PyObject *pyptr)
+{
+  struct gcguard *gg;
+  st_data_t key, val;
+
+  TypedData_Get_Struct(gcguard, struct gcguard, &gcguard_data_type, gg);
+
+  key = (st_data_t)pyptr;
+  st_delete(gg->guarded_objects, &key, &val);
+}
+
 static ID id_gcguard_table;
 static PyObject *weakref_callback_pyobj;
 static PyObject *gcguard_weakref_destroyed(PyObject *self, PyObject *weakref);
@@ -21,15 +87,15 @@ gcguard_weakref_destroyed(PyObject *self, PyObject *weakref)
 void
 pycall_gcguard_aset(PyObject *pyobj, VALUE rbobj)
 {
-  VALUE table = rb_ivar_get(mPyCall, id_gcguard_table);
-  rb_hash_aset(table, PTR2NUM(pyobj), rbobj);
+  VALUE gcguard = rb_ivar_get(mPyCall, id_gcguard_table);
+  gcguard_aset(gcguard, pyobj, rbobj);
 }
 
 void
 pycall_gcguard_delete(PyObject *pyobj)
 {
-  VALUE table = rb_ivar_get(mPyCall, id_gcguard_table);
-  rb_hash_delete(table, PTR2NUM(pyobj));
+  VALUE gcguard = rb_ivar_get(mPyCall, id_gcguard_table);
+  gcguard_delete(gcguard, pyobj);
 }
 
 void
@@ -64,11 +130,21 @@ pycall_gcguard_register(PyObject *pyobj, VALUE obj)
   pycall_gcguard_aset(wref, obj);
 }
 
+static VALUE
+gcguard_new(void)
+{
+  struct gcguard *gg;
+  VALUE obj = TypedData_Make_Struct(0, struct gcguard, &gcguard_data_type, gg);
+  gg->guarded_objects = st_init_numtable();
+
+  return obj;
+}
+
 void
 pycall_init_gcguard(void)
 {
   id_gcguard_table = rb_intern("gcguard_table");
-  rb_ivar_set(mPyCall, id_gcguard_table, rb_hash_new());
+  rb_ivar_set(mPyCall, id_gcguard_table, gcguard_new());
 
   weakref_callback_pyobj = Py_API(PyCFunction_NewEx)(&gcguard_weakref_callback_def, NULL, NULL);
 }

--- a/lib/pycall/wrapper_object_cache.rb
+++ b/lib/pycall/wrapper_object_cache.rb
@@ -6,7 +6,12 @@ module PyCall
     rescue
       WMAP_SUPPORT_INT_KEY = false
     else
-      WMAP_SUPPORT_INT_KEY = true
+      case RUBY_PLATFORM
+      when /cygwin/, /mingw/, /mswin/
+        WMAP_SUPPORT_INT_KEY = false
+      else
+        WMAP_SUPPORT_INT_KEY = true
+      end
     end
 
     if WMAP_SUPPORT_INT_KEY

--- a/spec/pycall/libpython/api_spec.rb
+++ b/spec/pycall/libpython/api_spec.rb
@@ -10,7 +10,7 @@ module PyCall
         it 'returns the different instance but the same address' do
           other = API.builtins_module_ptr
           expect(subject).not_to equal(other)
-          expect(subject.__address__).to equal(other.__address__)
+          expect(subject.__address__).to eq(other.__address__)
         end
       end
     end

--- a/spec/pycall_spec.rb
+++ b/spec/pycall_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe PyCall do
     it 'returns a Module that wraps a Python object' do
       expect(subject).to be_a(Module)
       expect(subject).to be_a(PyCall::PyObjectWrapper)
-      expect(subject.__pyptr__.__address__).to equal(PyCall::LibPython::API.builtins_module_ptr.__address__)
+      expect(subject.__pyptr__.__address__).to eq(PyCall::LibPython::API.builtins_module_ptr.__address__)
     end
 
     it 'returns the first-created wrapper module when called twice' do


### PR DESCRIPTION
To avoid object allocation during GC at `PTR2NUM` in `pycall_gcguard_delete`, I'd like to rewrite GC guard table with st_table with num hash.

This change potentially can fix SEGV occurred on Windows.