### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,8 +88,8 @@ ENV LANG C.UTF-8
 
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		tcl \
-		tk \
+		tcl=8.6.* \
+		tk=8.6.* \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
@@ -159,7 +159,7 @@ RUN cd /usr/local/bin \
 ###############################################################
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends libczmq-dev
+	&& apt-get install -y --no-install-recommends libczmq-dev=3.0.*
 
 RUN pip3 install jupyter
 RUN pip3 install numpy


### PR DESCRIPTION
Hi!
The Dockerfile placed at "docker/Dockerfile" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved using the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance