### PR TITLE
Add a candidate with LIBSUFFIX

### DIFF
--- a/lib/pycall/libpython/finder.rb
+++ b/lib/pycall/libpython/finder.rb
@@ -73,6 +73,7 @@ module PyCall
           if python_config[:LIBRARY]
             ext = File.extname(python_config[:LIBRARY])
             names << python_config[:LIBRARY].delete_suffix(ext) + suffix
+            names << python_config[:LIBRARY].delete_suffix(ext) + ".#{LIBSUFFIX}" 
           end
           dlprefix = if windows? then "" else "lib" end
           sysdata = {


### PR DESCRIPTION
Some conda base installations on macOS seems to prefer installing libpython as `.dylib` This PR adds one more candidate name.