### PR TITLE
Fix segvs

### DIFF
--- a/ext/pycall/libpython.c
+++ b/ext/pycall/libpython.c
@@ -217,6 +217,10 @@ pycall_init_libpython_api_table(VALUE libpython_handle)
     INIT_API_TABLE_ENTRY2(PyUnicode_DecodeUTF8, PyUnicodeUCS2_DecodeUTF8, required);
     INIT_API_TABLE_ENTRY2(PyUnicode_FromFormatV, PyUnicodeUCS2_FromFormatV, required);
   }
+
+  INIT_API_TABLE_ENTRY(PyGILState_Check, required);
+  INIT_API_TABLE_ENTRY(PyGILState_Ensure, required);
+  INIT_API_TABLE_ENTRY(PyGILState_Release, required);
 }
 
 void

--- a/ext/pycall/pycall.c
+++ b/ext/pycall/pycall.c
@@ -139,7 +139,15 @@ pycall_pyptr_free(void *ptr)
     fprintf(stderr, "zero refcnt object %p of type %s\n", pyobj, Py_TYPE(pyobj)->tp_name);
   }
 #endif /* PYCALL_DEBUG_DUMP_REFCNT */
-  pycall_Py_DecRef(pyobj);
+
+  if (Py_API(PyGILState_Check())) {
+    pycall_Py_DecRef(pyobj);
+  }
+  else {
+    PyGILState_STATE gstate = Py_API(PyGILState_Ensure)();
+    pycall_Py_DecRef(pyobj);
+    Py_API(PyGILState_Release)(gstate);
+  }
 }
 
 static size_t _PySys_GetSizeOf(PyObject *);

--- a/ext/pycall/pycall_internal.h
+++ b/ext/pycall/pycall_internal.h
@@ -519,6 +519,11 @@ PyObject * PyRuby_New(VALUE ruby_object);
 
 /* ==== thread support ==== */
 
+typedef enum {
+  PyGILState_LOCKED,
+  PyGILState_UNLOCKED
+} PyGILState_STATE;
+
 #if   defined(PYCALL_THREAD_WIN32)
 typedef DWORD pycall_tls_key;
 #elif defined(PYCALL_THREAD_PTHREAD)
@@ -669,6 +674,10 @@ typedef struct {
   PyObject * (* PyUnicode_AsUTF8String)(PyObject *);
   PyObject * (* PyUnicode_DecodeUTF8)(char const*, Py_ssize_t, char const *);
   PyObject * (* PyUnicode_FromFormatV)(char const*, ...);
+
+  int (* PyGILState_Check)(void);
+  PyGILState_STATE (* PyGILState_Ensure)(void);
+  void (* PyGILState_Release)(PyGILState_STATE);
 } pycall_libpython_api_table_t;
 
 pycall_libpython_api_table_t *pycall_libpython_api_table(void);

--- a/ext/pycall/ruby_wrapper.c
+++ b/ext/pycall/ruby_wrapper.c
@@ -59,10 +59,11 @@ PyObject *
 PyRuby_New(VALUE ruby_object)
 {
   if (!ruby_thread_has_gvl_p()) {
-    CALL_WITH_GVL(PyRuby_New_impl, ruby_object);
+    return CALL_WITH_GVL(PyRuby_New_impl, ruby_object);
   }
-
-  return PyRuby_New_impl(ruby_object);
+  else {
+    return PyRuby_New_impl(ruby_object);
+  }
 }
 
 static void *
@@ -90,7 +91,9 @@ PyRuby_dealloc_with_gvl(PyRubyObject *pyro)
   if (!ruby_thread_has_gvl_p()) {
     CALL_WITH_GVL(PyRuby_dealloc, pyro);
   }
-  PyRuby_dealloc(pyro);
+  else {
+    PyRuby_dealloc(pyro);
+  }
 }
 
 static PyObject *
@@ -114,7 +117,9 @@ PyRuby_repr_with_gvl(PyRubyObject *pyro)
   if (!ruby_thread_has_gvl_p()) {
     return CALL_WITH_GVL(PyRuby_repr, pyro);
   }
-  return PyRuby_repr(pyro);
+  else {
+    return PyRuby_repr(pyro);
+  }
 }
 
 #if SIZEOF_SSIZE_T < 8
@@ -154,7 +159,9 @@ PyRuby_hash_long_with_gvl(PyRubyObject *pyro)
   if (!ruby_thread_has_gvl_p()) {
     return (long)(intptr_t)CALL_WITH_GVL(PyRuby_hash_long, pyro);
   }
-  return (long)(intptr_t)PyRuby_hash_long(pyro);
+  else {
+    return (long)(intptr_t)PyRuby_hash_long(pyro);
+  }
 }
 
 static void *
@@ -185,7 +192,9 @@ PyRuby_hash_hash_t_with_gvl(PyRubyObject *pyro)
   if (!ruby_thread_has_gvl_p()) {
     return (Py_hash_t)CALL_WITH_GVL(PyRuby_hash_hash_t, pyro);
   }
-  return (Py_hash_t)PyRuby_hash_hash_t(pyro);
+  else {
+    return (Py_hash_t)PyRuby_hash_hash_t(pyro);
+  }
 }
 
 struct call_rb_funcallv_params {
@@ -269,8 +278,9 @@ PyRuby_call_with_gvl(PyRubyObject *pyro, PyObject *pyobj_args, PyObject *pyobj_k
   if (!ruby_thread_has_gvl_p()) {
     return CALL_WITH_GVL(PyRuby_call, &params);
   }
-
-  return PyRuby_call(&params);
+  else {
+    return PyRuby_call(&params);
+  }
 }
 
 struct PyRuby_getattro_params {
@@ -348,8 +358,9 @@ PyRuby_getattro_with_gvl(PyRubyObject *pyro, PyObject *pyobj_name)
   if (!ruby_thread_has_gvl_p()) {
     return CALL_WITH_GVL(PyRuby_getattro, &params);
   }
-
-  return PyRuby_getattro(&params);
+  else {
+    return PyRuby_getattro(&params);
+  }
 }
 
 /* ==== PyCall::PyRubyPtr ==== */


### PR DESCRIPTION
This patch fixes the following SEGVs.

1. SEGV on PyPtr finalizer that is called on non-main threads due to GC sweeper
2. SEGV on Ruby process finalization phase