### PR TITLE
at_exit: call Py_FinalizeEx()

### DIFF
--- a/ext/pycall/libpython.c
+++ b/ext/pycall/libpython.c
@@ -89,6 +89,7 @@ pycall_init_libpython_api_table(VALUE libpython_handle)
   INIT_API_TABLE_ENTRY(PyUnicode_Type, required);
 
   INIT_API_TABLE_ENTRY(Py_InitializeEx, required);
+  INIT_API_TABLE_ENTRY(Py_FinalizeEx, required);
   INIT_API_TABLE_ENTRY(Py_IsInitialized, required);
   INIT_API_TABLE_ENTRY(Py_GetVersion, required);
 

--- a/ext/pycall/pycall.c
+++ b/ext/pycall/pycall.c
@@ -681,6 +681,15 @@ pycall_libpython_api_PyList_GetItem(VALUE mod, VALUE pyptr, VALUE idx)
   return pycall_pyptr_new(pyobj_item);
 }
 
+static VALUE
+pycall_libpython_api_Py_FinalizeEx(VALUE mod)
+{
+  assert(Py_API(Py_IsInitialized()));
+
+  return Py_API(Py_FinalizeEx)();
+}
+
+
 /* ==== PyCall::Helpers ==== */
 
 static VALUE
@@ -2155,6 +2164,8 @@ init_python(void)
 {
   static char const *argv[1] = { "" };
 
+  printf("PYCALL.C: init_python\n");
+
   /* optional functions */
   if (! Py_API(PyObject_DelAttrString)) {
     /* The case of PyObject_DelAttrString as a macro */
@@ -2372,6 +2383,7 @@ Init_pycall(void)
   rb_define_module_function(mAPI, "PyObject_Dir", pycall_libpython_api_PyObject_Dir, 1);
   rb_define_module_function(mAPI, "PyList_Size", pycall_libpython_api_PyList_Size, 1);
   rb_define_module_function(mAPI, "PyList_GetItem", pycall_libpython_api_PyList_GetItem, 2);
+  rb_define_module_function(mAPI, "Py_FinalizeEx", pycall_libpython_api_Py_FinalizeEx, 0);
 
   /* PyCall::LibPython::Helpers */
 

--- a/ext/pycall/pycall_internal.h
+++ b/ext/pycall/pycall_internal.h
@@ -565,6 +565,7 @@ typedef struct {
   PyObject *PyExc_TypeError;
 
   void (* Py_InitializeEx)(int);
+  int (* Py_FinalizeEx)(void);
   int (* Py_IsInitialized)();
   char const * (* Py_GetVersion)();
 


### PR DESCRIPTION
Currently if you use PyCall from a thread OTHER than main, when you exit the process does not exit. This PR fixes that, by calling [Py_FinalizeEx()](https://docs.python.org/3/c-api/init.html#c.Py_FinalizeEx) `at_exit`. Once `PyFinalizeEx` is called, Python resources are cleaned up (possibly including threads that were blocking application exit?).

A possible advantage of this PR: it cleans up python memory before exit, which might (?) be good for using valgrind, etc.

Fixes #186 