### PR TITLE
fix 'Failure/Error: expect(out.chomp).to eq('true')' in riscv64 for Bundler/gem analysis.

### DIFF
--- a/spec/pycall_spec.rb
+++ b/spec/pycall_spec.rb
@@ -152,7 +152,7 @@ require 'pycall'
 puts(PyCall.init ? 'true' : 'false')
 RUBY
       expect(status).to be_success
-      expect(out.chomp).to eq('true')
+      expect(out.lines.last.chomp).to eq('true')
     end
 
     it 'returns false if already initialized' do


### PR DESCRIPTION
# Description:

There is a problem with the test code of the ruby-pycall 1.5.2-4 package. The package builds failed under the riscv64 and goes well under x86-64 architectures. According to the log output, the signature test file reported an error when entering the test phase.

```
Failures:

  1) PyCall.init returns true if initialization was succeeded
     Failure/Error: expect(out.chomp).to eq('true')

       expected: "true"
            got: "Resolving dependencies...\ntrue"

       (compared using ==)

       Diff:
       @@ -1 +1,2 @@
       +Resolving dependencies...
        true
     # ./spec/pycall_spec.rb:155:in `block (3 levels) in <top (required)>'

```

* package version(s):ruby-pycall 1.5.2-4
* config and/or log files:
[ruby-pycall-1.5.2-4-riscv64-check.log](https://github.com/user-attachments/files/19308425/ruby-pycall-1.5.2-4-riscv64-check.log)


My operating environment is the riscv64 environment virtual machine of the arch architecture of Windows WSL.
The process is as follows:
1. I cloned your project and installed the dependencies
2. Then execute py.test
3. Wait for about 7 seconds and find an error

# Patch
I modified the test file. Here are my ideas for modification：


This is the relevant code for the command line truncation error in /spec/pycall_spec.rb
```
require 'pycall'
puts(PyCall.init ? 'true' : 'false')
RUBY
      expect(status).to be_success
      expect(out.chomp).to eq('true')
    end

    it 'returns false if already initialized' do
      out, err, status = ruby(<<RUBY)
```


The test expects the output to be 'true', but the actual output includes an extra line Resolving dependencies...

This means that PyCall.init prints some extra information while initializing, such as "resolving dependencies" or loading libraries. On the specific architecture of riscv64, it may add some extra logging output.
To fix this, the assertion in the test can be adjusted to not strictly require every part of the output, but only focus on the last line of the output. This can be achieved by modifying the `expect(out.chomp).to eq('true')` statement in the test to ensure that the test only focuses on the last line of output.
`expect(out.lines.last.chomp).to eq('true')`


Do you think this is a good change?