### PR TITLE
Suppress "string returned by #{symbol} will be frozen in the future" warnings

### DIFF
--- a/lib/pycall/pyobject_wrapper.rb
+++ b/lib/pycall/pyobject_wrapper.rb
@@ -33,8 +33,6 @@ module PyCall
     }.freeze
 
     def method_missing(name, *args)
-      name_str = name.to_s if name.kind_of?(Symbol)
-      name_str.chop! if name_str.end_with?('=')
       case name
       when *OPERATOR_METHOD_NAMES.keys
         op_name = OPERATOR_METHOD_NAMES[name]
@@ -44,7 +42,8 @@ module PyCall
           return self.__send__(name, *args)
         end
       else
-        if LibPython::Helpers.hasattr?(__pyptr__, name_str)
+        name_without_last_equal = name.to_s.chomp('=')
+        if LibPython::Helpers.hasattr?(__pyptr__, name_without_last_equal)
           LibPython::Helpers.define_wrapper_method(self, name)
           return self.__send__(name, *args)
         end


### PR DESCRIPTION
For example:

https://github.com/red-data-tools/charty/actions/runs/14327259034/job/40155029515#step:12:1596

    pycall-1.5.2/lib/pycall/pyobject_wrapper.rb:37: warning: string returned by :index=.to_s will be frozen in the future

This warnings is started from Ruby 3.4.